### PR TITLE
FolderId constructor fix

### DIFF
--- a/js/ComplexProperties/FolderId.js
+++ b/js/ComplexProperties/FolderId.js
@@ -24,8 +24,8 @@ var FolderId = /** @class */ (function (_super) {
     //        this.mailbox = mailbox;
     //        this.folderName = folderName;
     //    }
-    function FolderId(folderName, mailbox) {
-        var _this = _super.call(this) || this;
+    function FolderId(uniqueId, folderName, mailbox) {
+        var _this = _super.call(this, uniqueId) || this;
         _this.mailbox = mailbox;
         _this.folderName = folderName;
         return _this;

--- a/js/ComplexProperties/FolderId.js
+++ b/js/ComplexProperties/FolderId.js
@@ -24,7 +24,7 @@ var FolderId = /** @class */ (function (_super) {
     //        this.mailbox = mailbox;
     //        this.folderName = folderName;
     //    }
-    function FolderId(uniqueId, folderName, mailbox) {
+    function FolderId(folderName, mailbox, uniqueId) {
         var _this = _super.call(this, uniqueId) || this;
         _this.mailbox = mailbox;
         _this.folderName = folderName;


### PR DESCRIPTION
While i was working on creation of contact in specific folder i found a bug that i cannot create proper instance of FolderId class using only UniqueId of folder.